### PR TITLE
Data ingestion: download and load dataset

### DIFF
--- a/src/ingest_data.py
+++ b/src/ingest_data.py
@@ -8,6 +8,7 @@ from Kaggle and stores it in the raw data folder.
 # Import required libraries
 import subprocess
 import os
+import pandas as pd
 
 
 def download_dataset_from_kaggle():
@@ -33,6 +34,17 @@ def download_dataset_from_kaggle():
 
     print("Dataset successfully downloaded to data/raw")
 
+def load_raw_dataset():
+    """
+    Load the raw dataset into a dataframe
+    """
+    
+    file_path = "data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv"
+    print("Loading dataset from:", file_path)
+    df = pd.read_csv(file_path)
+    print("Raw dataset loaded successfully. Shape:", df.shape)
+    return df
 
 if __name__ == "__main__":
     download_dataset_from_kaggle()
+    df = load_raw_dataset()


### PR DESCRIPTION
- Added data ingestion script using Kaggle CLI
- Downloads Telco Customer Churn dataset to data/raw/
- Added simple function to load dataset using pandas

Closes issue #4 

Note: Implementation uses the Kaggle CLI for ingestion. Assumption is that user has Kaggle API configured locally. 